### PR TITLE
Reduce frequency of requests to Hy-Vee APIs

### DIFF
--- a/Routes/hyvee.js
+++ b/Routes/hyvee.js
@@ -176,4 +176,4 @@ function getAllMetrics() {
 
 setInterval(() => {
   searchPharmacies();
-}, 1 * 1000);
+}, 60 * 1000);


### PR DESCRIPTION
Hi Jerod, I am a software engineer on Hy-Vee's pharmacy team. Thank you for taking the time to help your community and build this useful tool!

I am reaching out because we noticed this application has been sending a considerable amount of requests to our APIs. Other applications and bots in the community have found success retrieving vaccine availability around once per minute or less. Would you consider doing the same to reduce the load on our systems?